### PR TITLE
Fixes #6: Misattribution of test output

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -211,6 +211,7 @@ func finish(evt tokenizer.Event, pkgTracker *packageTracker, result Result) {
 				Coverage: evt.Coverage,
 			},
 		)
+		pkgTracker.currentPackage = nil
 	}
 }
 

--- a/testdata/misattribution.parser.json
+++ b/testdata/misattribution.parser.json
@@ -1,0 +1,35 @@
+{
+  "prefix": null,
+  "downloads": {
+    "packages": null,
+    "failed": false
+  },
+  "packages": [
+    {
+      "name": "github.com/haveyoudebuggedit/gotestfmt/renderer",
+      "result": "SKIP",
+      "duration": "0s",
+      "coverage": null,
+      "output": "",
+      "testcases": null,
+      "reason": "no test files"
+    },
+    {
+      "name": "github.com/haveyoudebuggedit/gotestfmt/testutil",
+      "result": "PASS",
+      "duration": "5.003s",
+      "coverage": null,
+      "output": "",
+      "testcases": [
+        {
+          "name": "TestSleep",
+          "result": "PASS",
+          "duration": "5s",
+          "coverage": null,
+          "output": "    sleep_test.go:10: Now sleeping for 5 seconds...\n    sleep_test.go:12: Welcome back, now finishing test."
+        }
+      ],
+      "reason": ""
+    }
+  ]
+}

--- a/testdata/misattribution.tokenizer.json
+++ b/testdata/misattribution.tokenizer.json
@@ -1,0 +1,72 @@
+[
+  {
+    "action": "skip",
+    "package": "github.com/haveyoudebuggedit/gotestfmt/renderer",
+    "version": "",
+    "test": "",
+    "elapsed": "0s",
+    "output": "bm8gdGVzdCBmaWxlcw==",
+    "cached": false,
+    "coverage": null
+  },
+  {
+    "action": "run",
+    "package": "",
+    "version": "",
+    "test": "TestSleep",
+    "elapsed": "0s",
+    "output": null,
+    "cached": false,
+    "coverage": null
+  },
+  {
+    "action": "stdout",
+    "package": "",
+    "version": "",
+    "test": "",
+    "elapsed": "0s",
+    "output": "ICAgIHNsZWVwX3Rlc3QuZ286MTA6IE5vdyBzbGVlcGluZyBmb3IgNSBzZWNvbmRzLi4u",
+    "cached": false,
+    "coverage": null
+  },
+  {
+    "action": "stdout",
+    "package": "",
+    "version": "",
+    "test": "",
+    "elapsed": "0s",
+    "output": "ICAgIHNsZWVwX3Rlc3QuZ286MTI6IFdlbGNvbWUgYmFjaywgbm93IGZpbmlzaGluZyB0ZXN0Lg==",
+    "cached": false,
+    "coverage": null
+  },
+  {
+    "action": "pass",
+    "package": "",
+    "version": "",
+    "test": "TestSleep",
+    "elapsed": "5s",
+    "output": null,
+    "cached": false,
+    "coverage": null
+  },
+  {
+    "action": "pass-final",
+    "package": "",
+    "version": "",
+    "test": "",
+    "elapsed": "0s",
+    "output": null,
+    "cached": false,
+    "coverage": null
+  },
+  {
+    "action": "pass",
+    "package": "github.com/haveyoudebuggedit/gotestfmt/testutil",
+    "version": "",
+    "test": "",
+    "elapsed": "5.003s",
+    "output": null,
+    "cached": false,
+    "coverage": null
+  }
+]

--- a/testdata/misattribution.txt
+++ b/testdata/misattribution.txt
@@ -1,0 +1,7 @@
+?       github.com/haveyoudebuggedit/gotestfmt/renderer [no test files]
+=== RUN   TestSleep
+    sleep_test.go:10: Now sleeping for 5 seconds...
+    sleep_test.go:12: Welcome back, now finishing test.
+--- PASS: TestSleep (5.00s)
+PASS
+ok      github.com/haveyoudebuggedit/gotestfmt/testutil 5.003s

--- a/testdata/testifymultipackage.parser.json
+++ b/testdata/testifymultipackage.parser.json
@@ -11,6 +11,15 @@
       "duration": "75ms",
       "coverage": null,
       "output": "",
+      "testcases": null,
+      "reason": ""
+    },
+    {
+      "name": "github.com/haveyoudebuggedit/example/subpackage2",
+      "result": "FAIL",
+      "duration": "75ms",
+      "coverage": null,
+      "output": "",
       "testcases": [
         {
           "name": "TestTestify",
@@ -20,15 +29,6 @@
           "output": "    testify_test.go:10:\n                Error Trace:    testify_test.go:10\n                Error:          Not equal:\n                                expected: 50\n                                actual  : 48\n                Test:           TestTestify"
         }
       ],
-      "reason": ""
-    },
-    {
-      "name": "github.com/haveyoudebuggedit/example/subpackage2",
-      "result": "FAIL",
-      "duration": "75ms",
-      "coverage": null,
-      "output": "",
-      "testcases": null,
       "reason": ""
     }
   ]


### PR DESCRIPTION
## Please describe the change you are making

This change fixes #6, where test output was misattributed to the wrong package.

## Your code will be released under [the Unlicense](LICENSE.md) into the public domain for everyone to use for any purpose. Are you in the position, and are you willing to release your code under this license?

Yes
