### PR TITLE
Add flag to show test status as a word next to the icons

### DIFF
--- a/.gotestfmt/github/package.gotpl
+++ b/.gotestfmt/github/package.gotpl
@@ -24,14 +24,14 @@ we are creating a stylized header for each package.
             {{- if or (not $settings.HideSuccessfulTests) (ne .Result "PASS") -}}
                 ::group::
                 {{- if eq .Result "PASS" -}}
-                    {{ "\033" }}[0;32m✅{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
+                    {{ "\033" }}[0;32m✅
                 {{- else if eq .Result "SKIP" -}}
-                    {{ "\033" }}[0;33m🚧{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
+                    {{ "\033" }}[0;33m🚧
                 {{- else -}}
-                    {{ "\033" }}[0;31m❌{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
+                    {{ "\033" }}[0;31m❌
                 {{- end -}}
                 {{ " " }}{{- .Name -}}
-                {{- "\033" -}}[0;37m ({{ .Duration -}}
+                {{- "\033" -}}[0;37m ({{if $settings.ShowTestStatus}}{{.Result}}; {{end}}{{ .Duration -}}
                 {{- with .Coverage -}}
                     , coverage: {{ . }}%
                 {{- end -}})

--- a/.gotestfmt/github/package.gotpl
+++ b/.gotestfmt/github/package.gotpl
@@ -24,11 +24,11 @@ we are creating a stylized header for each package.
             {{- if or (not $settings.HideSuccessfulTests) (ne .Result "PASS") -}}
                 ::group::
                 {{- if eq .Result "PASS" -}}
-                    {{ "\033" }}[0;32m✅
+                    {{ "\033" }}[0;32m✅{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
                 {{- else if eq .Result "SKIP" -}}
-                    {{ "\033" }}[0;33m🚧
+                    {{ "\033" }}[0;33m🚧{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
                 {{- else -}}
-                    {{ "\033" }}[0;31m❌
+                    {{ "\033" }}[0;31m❌{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
                 {{- end -}}
                 {{ " " }}{{- .Name -}}
                 {{- "\033" -}}[0;37m ({{ .Duration -}}

--- a/.gotestfmt/gitlab/package.gotpl
+++ b/.gotestfmt/gitlab/package.gotpl
@@ -25,11 +25,11 @@ we are creating a stylized header for each package.
             {{- if or (not $settings.HideSuccessfulTests) (ne .Result "PASS") -}}
                 {{- "\033[0K" }}section_start:{{ with .StartTime }}{{ .Unix }}{{ else }}0{{ end }}:{{ .ID }}[collapsed=true]{{- "\r\033[0K" -}}
                 {{- if eq .Result "PASS" -}}
-                    {{- "\033[0;32m  " }}✅
+                    {{- "\033[0;32m  " }}✅{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
                 {{- else if eq .Result "SKIP" -}}
-                    {{- "\033[0;33m  " }}🚧
+                    {{- "\033[0;33m  " }}🚧{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
                 {{- else -}}
-                    {{- "\033[0;31m  " }}❌
+                    {{- "\033[0;31m  " }}❌{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
                 {{- end -}}
                 {{- " " }}{{- .Name -}}
                 {{- with .Coverage -}}{{- " \033" -}}[0;37m (coverage: {{ . }}%){{- end -}}

--- a/.gotestfmt/package.gotpl
+++ b/.gotestfmt/package.gotpl
@@ -22,11 +22,11 @@ This template contains the format for an individual package.
         {{- range . -}}
             {{- if or (not $settings.HideSuccessfulTests) (ne .Result "PASS") -}}
                 {{- if eq .Result "PASS" -}}
-                    {{ "  \033" }}[0;32m✅
+                    {{ "  \033" }}[0;32m✅{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
                 {{- else if eq .Result "SKIP" -}}
-                    {{ "  \033" }}[0;33m🚧
+                    {{ "  \033" }}[0;33m🚧{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
                 {{- else -}}
-                    {{ "  \033" }}[0;31m❌
+                    {{ "  \033" }}[0;31m❌{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
                 {{- end -}}
                 {{ " " }}{{- .Name -}}
                 {{- "\033" -}}[0;37m ({{ .Duration -}}

--- a/.gotestfmt/package.gotpl
+++ b/.gotestfmt/package.gotpl
@@ -22,14 +22,14 @@ This template contains the format for an individual package.
         {{- range . -}}
             {{- if or (not $settings.HideSuccessfulTests) (ne .Result "PASS") -}}
                 {{- if eq .Result "PASS" -}}
-                    {{ "  \033" }}[0;32m✅{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
+                    {{ "  \033" }}[0;32m✅
                 {{- else if eq .Result "SKIP" -}}
-                    {{ "  \033" }}[0;33m🚧{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
+                    {{ "  \033" }}[0;33m🚧
                 {{- else -}}
-                    {{ "  \033" }}[0;31m❌{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
+                    {{ "  \033" }}[0;31m❌
                 {{- end -}}
                 {{ " " }}{{- .Name -}}
-                {{- "\033" -}}[0;37m ({{ .Duration -}}
+                {{- "\033" -}}[0;37m ({{if $settings.ShowTestStatus}}{{.Result}}; {{end}}{{ .Duration -}}
                 {{- with .Coverage -}}
                     , coverage: {{ . }}%
                 {{- end -}})

--- a/.gotestfmt/teamcity/package.gotpl
+++ b/.gotestfmt/teamcity/package.gotpl
@@ -16,24 +16,24 @@ we are creating a stylized header for each package.
     {{- with .TestCases -}}
         {{- range . -}}
             {{- if or (not $settings.HideSuccessfulTests) (ne .Result "PASS") -}}
+                {{- if $settings.ShowTestStatus -}}
+                {{- $title := print .Name " (" .Result "; " .Duration -}}
+                {{- else -}}
                 {{- $title := print .Name " (" .Duration -}}
+                {{- end -}}
                 {{- with .Coverage -}}
                     {{- $title = print ", coverage: " . "%" -}}
                 {{- end -}})
                 {{- $title = print $title ")" -}}
-                {{- $icon = "" -}}
                 {{- if eq .Result "PASS" -}}
-                    {{- $icon = "✅" -}}
+                    {{- $title = print "✅ " $title -}}
                 {{- else if eq .Result "SKIP" -}}
-                    {{- $icon = "🚧" -}}
+                    {{- $title = print "🚧 " $title -}}
                 {{- else -}}
-                    {{- $icon = "❌" -}}
+                    {{- $title = print "❌ " $title -}}
                 {{- end -}}
-                {{- if $settings.ShowTestStatus -}}
-                    {{- $icon = print $icon " (" .Result ")" -}}
-                {{- end -}}
-                {{- $title = print $icon " " $title -}}
                 {{- "\n" -}}
+
                 ##teamcity[blockOpened name='{{- $title -}}']{{- "\n" -}}
                 {{- with .Output -}}
                     {{- . -}}

--- a/.gotestfmt/teamcity/package.gotpl
+++ b/.gotestfmt/teamcity/package.gotpl
@@ -32,7 +32,7 @@ we are creating a stylized header for each package.
                 {{- if $settings.ShowTestStatus -}}
                     {{- $icon = print $icon " (" .Result ")" -}}
                 {{- end -}}
-								{{- $title = print $icon " " $title -}}
+                {{- $title = print $icon " " $title -}}
                 {{- "\n" -}}
                 ##teamcity[blockOpened name='{{- $title -}}']{{- "\n" -}}
                 {{- with .Output -}}

--- a/.gotestfmt/teamcity/package.gotpl
+++ b/.gotestfmt/teamcity/package.gotpl
@@ -21,15 +21,19 @@ we are creating a stylized header for each package.
                     {{- $title = print ", coverage: " . "%" -}}
                 {{- end -}})
                 {{- $title = print $title ")" -}}
+                {{- $icon = "" -}}
                 {{- if eq .Result "PASS" -}}
-                    {{- $title = print "✅ " $title -}}
+                    {{- $icon = "✅" -}}
                 {{- else if eq .Result "SKIP" -}}
-                    {{- $title = print "🚧 " $title -}}
+                    {{- $icon = "🚧" -}}
                 {{- else -}}
-                    {{- $title = print "❌ " $title -}}
+                    {{- $icon = "❌" -}}
                 {{- end -}}
+                {{- if $settings.ShowTestStatus -}}
+                    {{- $icon = print $icon " (" .Result ")" -}}
+                {{- end -}}
+								{{- $title = print $icon " " $title -}}
                 {{- "\n" -}}
-
                 ##teamcity[blockOpened name='{{- $title -}}']{{- "\n" -}}
                 {{- with .Output -}}
                     {{- . -}}

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ jobs:
         with:
           # Optional: pass GITHUB_TOKEN to avoid rate limiting.
           token: ${{ secrets.GITHUB_TOKEN }}
-          
+
       # Alternatively, install using go install
       - name: Set up gotestfmt
         run: go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
@@ -137,7 +137,7 @@ FROM golang
 COPY --from gotestfmt /gotestfmt /usr/local/bin/
 ```
 
-You can then run the tests within this image with the following command:   
+You can then run the tests within this image with the following command:
 
 ```bash
 go test -json -v ./... | /usr/local/bin/gotestfmt
@@ -269,6 +269,7 @@ Render settings are available in all templates. They have the following fields:
 | `.HideSuccessfulPackages` | `bool` | Hide all packages that have only successful tests from the output. |
 | `.HideEmptyPackages` | `bool` | Hide the packages from the output that have no test cases. |
 | `.HideSuccessfulTests` | `bool` | Hide all tests from the output that are successful. |
+| `.ShowTestStatus` | `bool` | Show the test status next to the icons (PASS, FAIL, SKIP). |
 
 ## FAQ
 
@@ -283,6 +284,12 @@ By default, `gotestfmt` will output all tests and their logs. However, you can u
 - **`all`:** Hide all non-error items.
 
 ⚠️ This feature depends on the template you use. If you customized your template please make sure to check the [Render settings](#render-settings) object in your code.
+
+### How do I know what the icons mean in the output?
+
+The icons are based on the output of `go test -json`. They map to the values from the `[test2json](https://pkg.go.dev/cmd/test2json) package which are PASS, FAIL and SKIP.
+
+You can use the `-showteststatus` flag to output the words next to the icons in the output.
 
 ### Can I use gotestfmt without `-json`?
 
@@ -309,9 +316,9 @@ There are more awesome tools out there:
 - [ContainerSSH](https://github.com/containerssh/libcontainerssh)
 - [go-ovirt-client](https://github.com/ovirt/go-ovirt-client)
 - [go-ovirt-client-log-klog](https://github.com/ovirt/go-ovirt-client-log-klog)
-- [...and more!](https://github.com/search?q=gotestfmt&type=code) 
+- [...and more!](https://github.com/search?q=gotestfmt&type=code)
 
-*To add your name here simply click the pen icon on top of this box. Please use alphabetic order.* 
+*To add your name here simply click the pen icon on top of this box. Please use alphabetic order.*
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -287,9 +287,9 @@ By default, `gotestfmt` will output all tests and their logs. However, you can u
 
 ### How do I know what the icons mean in the output?
 
-The icons are based on the output of `go test -json`. They map to the values from the `[test2json](https://pkg.go.dev/cmd/test2json) package which are PASS, FAIL and SKIP.
+The icons are based on the output of `go test -json`. They map to the values from the [`test2json`](https://pkg.go.dev/cmd/test2json) package (PASS, FAIL, SKIP).
 
-You can use the `-showteststatus` flag to output the words next to the icons in the output.
+You can use the `-showteststatus` flag to output the words next to the icons.
 
 ### Can I use gotestfmt without `-json`?
 

--- a/cmd/gotestfmt/main.go
+++ b/cmd/gotestfmt/main.go
@@ -96,6 +96,8 @@ func main() {
 	ci := ""
 	inputFile := "-"
 	hide := ""
+	var showTestStatus bool
+
 	flag.StringVar(
 		&ci,
 		"ci",
@@ -113,6 +115,12 @@ func main() {
 		"hide",
 		hide,
 		hideDescription(),
+	)
+	flag.BoolVar(
+		&showTestStatus,
+		"showteststatus",
+		showTestStatus,
+		"Show the test status next to the icons (PASS, FAIL, SKIP).",
 	)
 	flag.Parse()
 
@@ -133,6 +141,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	cfg.ShowTestStatus = showTestStatus
 
 	format, err := gotestfmt.New(
 		dirs,

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -116,4 +116,6 @@ type RenderSettings struct {
 	HideEmptyPackages bool
 	// HideSuccessfulTests hides all tests from the output that are successful.
 	HideSuccessfulTests bool
+	// ShowTestStatus adds words to indicate the test status next to the icons (PASS, FAIl, SKIP).
+	ShowTestStatus bool
 }


### PR DESCRIPTION
## Please describe the change you are making

It may not be obvious what the icons represent, particularly the one for "SKIP". This adds a bit of documentation and a flag to show the status as a word next to the icon.

## Your code will be released under [the Unlicense](LICENSE.md) into the public domain for everyone to use for any purpose. Are you in the position, and are you willing to release your code under this license?

Yes.