### PR TITLE
Fixes #23: Code coverage not shown with default templates

### DIFF
--- a/.gotestfmt/github/package.gotpl
+++ b/.gotestfmt/github/package.gotpl
@@ -12,7 +12,11 @@ we are creating a stylized header for each package.
     {{- else -}}
         {{ "\033" }}[0;31m
     {{- end -}}
-    📦 {{ .Name }}{{ "\033" }}[0m{{- "\n" -}}
+    📦 {{ .Name }}{{- "\033" }}[0m
+    {{- with .Coverage -}}
+       {{- "\033" -}}[0;37m ({{ . }}% coverage){{- "\033" -}}[0m
+    {{- end -}}
+    {{- "\n" -}}
     {{- with .Reason -}}
         {{- "  " -}}🛑 {{ . -}}{{- "\n" -}}
     {{- end -}}

--- a/.gotestfmt/gitlab/package.gotpl
+++ b/.gotestfmt/gitlab/package.gotpl
@@ -13,7 +13,11 @@ we are creating a stylized header for each package.
     {{- else -}}
         {{- "\033" }}[0;31m
     {{- end -}}
-    📦 {{ .Name }}{{ "\033" }}[0m{{- "\n" -}}
+    📦 {{ .Name }}{{- "\033" }}[0m
+    {{- with .Coverage -}}
+       {{- "\033" -}}[0;37m ({{ . }}% coverage){{- "\033" -}}[0m
+    {{- end -}}
+    {{- "\n" -}}
     {{- with .Reason -}}
       {{- "  " -}}🛑 {{ . -}}{{- "\n" -}}
     {{- end -}}
@@ -25,15 +29,15 @@ we are creating a stylized header for each package.
             {{- if or (not $settings.HideSuccessfulTests) (ne .Result "PASS") -}}
                 {{- "\033[0K" }}section_start:{{ with .StartTime }}{{ .Unix }}{{ else }}0{{ end }}:{{ .ID }}[collapsed=true]{{- "\r\033[0K" -}}
                 {{- if eq .Result "PASS" -}}
-                    {{- "\033[0;32m  " }}✅{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
+                    {{- "\033[0;32m  " }}✅
                 {{- else if eq .Result "SKIP" -}}
-                    {{- "\033[0;33m  " }}🚧{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
+                    {{- "\033[0;33m  " }}🚧
                 {{- else -}}
-                    {{- "\033[0;31m  " }}❌{{if $settings.ShowTestStatus}} ({{.Result}}){{end}}
+                    {{- "\033[0;31m  " }}❌
                 {{- end -}}
                 {{- " " }}{{- .Name -}}
-                {{- with .Coverage -}}{{- " \033" -}}[0;37m (coverage: {{ . }}%){{- end -}}
-                {{- "\033" -}}[0m
+                {{- "\033" -}}[0;37m ({{- if $settings.ShowTestStatus -}}{{- .Result -}}; {{- end -}}{{- .Duration -}}
+                ){{- "\033" -}}[0m
                 {{- "\n" -}}
 
                 {{- with .Output -}}

--- a/.gotestfmt/package.gotpl
+++ b/.gotestfmt/package.gotpl
@@ -11,7 +11,11 @@ This template contains the format for an individual package.
     {{- else -}}
         {{ "\033" }}[0;31m
     {{- end -}}
-    📦 {{ .Name }}{{ "\033" }}[0m{{- "\n" -}}
+    📦 {{ .Name -}}{{- "\033" }}[0m
+    {{- with .Coverage -}}
+        {{- "\033" -}}[0;37m ({{ . }}% coverage){{- "\033" -}}[0m
+    {{- end -}}
+    {{- "\n" -}}
     {{- with .Reason -}}
         {{- "  " -}}🛑 {{ . -}}{{- "\n" -}}
     {{- end -}}
@@ -29,13 +33,7 @@ This template contains the format for an individual package.
                     {{ "  \033" }}[0;31m❌
                 {{- end -}}
                 {{ " " }}{{- .Name -}}
-                {{- "\033" -}}[0;37m ({{if $settings.ShowTestStatus}}{{.Result}}; {{end}}{{ .Duration -}}
-                {{- with .Coverage -}}
-                    , coverage: {{ . }}%
-                {{- end -}})
-                {{- "\033" -}}[0m
-                {{- "\n" -}}
-
+                {{- "\033" -}}[0;37m ({{if $settings.ShowTestStatus}}{{.Result}}; {{end}}{{ .Duration -}}){{- "\033" -}}[0m{{- "\n" -}}
                 {{- with .Output -}}
                     {{- . -}}
                     {{- "\n" -}}

--- a/.gotestfmt/teamcity/downloads.gotpl
+++ b/.gotestfmt/teamcity/downloads.gotpl
@@ -29,6 +29,6 @@ This template contains the format for a package download.
                 {{- end -}}
             {{- end -}}
         {{- end -}}
-        ##teamcity[blockClosed name='{{ $$title }}']
+        ##teamcity[blockClosed name='{{ $title }}']
     {{- end -}}
 {{- end -}}

--- a/.gotestfmt/teamcity/package.gotpl
+++ b/.gotestfmt/teamcity/package.gotpl
@@ -5,8 +5,7 @@ we are creating a stylized header for each package.
 */ -}}
 {{- $settings := .Settings -}}
 {{- if and (or (not $settings.HideSuccessfulPackages) (ne .Result "PASS")) (or (not $settings.HideEmptyPackages) (ne .Result "SKIP") (ne (len .TestCases) 0)) -}}
-    {{- $packageTitle := print "📦 " .Name -}}
-    ##teamcity[blockOpened name='{{ $packageTitle }}']{{- "\n" -}}
+    ##teamcity[blockOpened name='📦 {{ .Name }}{{- with .Coverage }} ({{ . }}% coverage){{- end -}}']
     {{- with .Reason -}}
         {{- "  " -}}🛑 {{ . -}}{{- "\n" -}}
     {{- end -}}
@@ -16,15 +15,12 @@ we are creating a stylized header for each package.
     {{- with .TestCases -}}
         {{- range . -}}
             {{- if or (not $settings.HideSuccessfulTests) (ne .Result "PASS") -}}
+                {{- $title := "" -}}
                 {{- if $settings.ShowTestStatus -}}
-                {{- $title := print .Name " (" .Result "; " .Duration -}}
+                    {{- $title = print .Name " (" .Result "; " .Duration ")" -}}
                 {{- else -}}
-                {{- $title := print .Name " (" .Duration -}}
+                    {{- $title = print .Name " (" .Duration ")" -}}
                 {{- end -}}
-                {{- with .Coverage -}}
-                    {{- $title = print ", coverage: " . "%" -}}
-                {{- end -}})
-                {{- $title = print $title ")" -}}
                 {{- if eq .Result "PASS" -}}
                     {{- $title = print "✅ " $title -}}
                 {{- else if eq .Result "SKIP" -}}
@@ -43,5 +39,5 @@ we are creating a stylized header for each package.
             {{- end -}}
         {{- end -}}
     {{- end -}}
-    ##teamcity[blockClosed name='{{ $packageTitle }}']{{- "\n" -}}
+    ##teamcity[blockClosed name='📦 {{ .Name }}{{- with .Coverage }} ({{ . }}% coverage){{- end -}}']{{- "\n" -}}
 {{- end -}}

--- a/README.md
+++ b/README.md
@@ -213,63 +213,62 @@ When running on a well-known CI system, such as GitHub Actions, gotestfmt will d
 
 This file contains the output fragment showing the package downloads in the Go template format. It has the following variables available:
 
-| Variable | Type | Description |
-|----------|------|-------------|
-| `.Failed` | `bool` | Indicates an overall failure. |
-| `.Packages` | `[]Package` | A list of packages that have been processed. |
-| `.StartTime` | `*time.Time` | The time the first download line was seen. May be empty. |
-| `.EndTime` | `*time.Time` | The time the last download line was seen. May be empty. |
-| `.Settings` | [`RenderSettings`](#render-settings) | The render settings (what to hide, etc, [see below](#render-settings)). |
+| Variable     | Type                                 | Description                                                             |
+|--------------|--------------------------------------|-------------------------------------------------------------------------|
+| `.Failed`    | `bool`                               | Indicates an overall failure.                                           |
+| `.Packages`  | `[]Package`                          | A list of packages that have been processed.                            |
+| `.StartTime` | `*time.Time`                         | The time the first download line was seen. May be empty.                |
+| `.EndTime`   | `*time.Time`                         | The time the last download line was seen. May be empty.                 |
+| `.Settings`  | [`RenderSettings`](#render-settings) | The render settings (what to hide, etc, [see below](#render-settings)). |
 
 The `Package` items have the following format:
 
-| Variable | Type | Description |
-|----------|------|-------------|
+| Variable   | Type     | Description                                                          |
+|------------|----------|----------------------------------------------------------------------|
 | `.Package` | `string` | Name of the package. (e.g. `github.com/haveyoudebuggedit/gotestfmt`) |
-| `.Version` | `string` | Version of the package. (e.g. `v1.0.0`) |
-| `.Failed` | `bool` | If the package download has failed. |
-| `.Reason` | `string` | Text explaining the failure. |
+| `.Version` | `string` | Version of the package. (e.g. `v1.0.0`)                              |
+| `.Failed`  | `bool`   | If the package download has failed.                                  |
+| `.Reason`  | `string` | Text explaining the failure.                                         |
 
 #### package.tpl
 
 This template is the output format for the results of a single package and the tests in it. If multiple packages are tested, this template is called multiple times in a row. It has the following fields:
 
-| Variable | Type | Description |
-|----------|------|-------------|
-| `.Name`   | `string` | Name of the package under test.
-| `.Result` | `string` | Result of all tests in this package. Can be `PASS`, `FAIL`, or `SKIP`. |
-| `.Duration` | `time.Duration` | Duration of all test runs in this package. |
-| `.Coverage` | `*float64` | If coverage data was provided, this indicates the code coverage percentage. |
-| `.Output` | `string` | Additional output from failures. (e.g. syntax error indications) |
-| `.TestCases` | `[]TestCase` | A list of test case results. |
-| `.Reason` | `string` | Text explaining the failure. Empty in most cases. |
-| `.StartTime` | `*time.Time` | A pointer to a time object when the package was first seen in the output. May be nil. |
-| `.EndTime` | `*time.Time` | A pointer to the time object when the package was last seen in the output. May be nil. |
-| `.Settings` | [`RenderSettings`](#render-settings) | The render settings (what to hide, etc, [see below](#render-settings)). |
+| Variable     | Type                                 | Description                                                                            |
+|--------------|--------------------------------------|----------------------------------------------------------------------------------------|
+| `.Name`      | `string`                             | Name of the package under test.                                                        |
+| `.Result`    | `string`                             | Result of all tests in this package. Can be `PASS`, `FAIL`, or `SKIP`.                 |
+| `.Duration`  | `time.Duration`                      | Duration of all test runs in this package.                                             |
+| `.Coverage`  | `*float64`                           | If coverage data was provided, this indicates the code coverage percentage.            |
+| `.Output`    | `string`                             | Additional output from failures. (e.g. syntax error indications)                       |
+| `.TestCases` | `[]TestCase`                         | A list of test case results.                                                           |
+| `.Reason`    | `string`                             | Text explaining the failure. Empty in most cases.                                      |
+| `.StartTime` | `*time.Time`                         | A pointer to a time object when the package was first seen in the output. May be nil.  |
+| `.EndTime`   | `*time.Time`                         | A pointer to the time object when the package was last seen in the output. May be nil. |
+| `.Settings`  | [`RenderSettings`](#render-settings) | The render settings (what to hide, etc, [see below](#render-settings)).                |
 
 Test cases have the following format:
 
-| Variable | Type | Description |
-|----------|------|-------------|
-| `.Name` | `string` | Name of the test case. May contain slashes (`/`) if subtests are run. |
-| `.Result` | `string` | Result of the test. Can be `PASS`, `FAIL`, or `SKIP`. |
-| `.Duration` | `time.Duration` | Duration of all test runs in this package. |
-| `.Coverage` | `float64` | If coverage data was provided, this indicates the code coverage percentage. Contains a negative number if no coverage data is available. |
-| `.Output` | `string` | Log output from the test. |
-| `.StartTime` | `*time.Time` | A pointer to a time object when the test case was first seen in the output. May be nil. |
-| `.EndTime` | `*time.Time` | A pointer to the time object when the test case was last seen in the output. May be nil. |
+| Variable     | Type            | Description                                                                              |
+|--------------|-----------------|------------------------------------------------------------------------------------------|
+| `.Name`      | `string`        | Name of the test case. May contain slashes (`/`) if subtests are run.                    |
+| `.Result`    | `string`        | Result of the test. Can be `PASS`, `FAIL`, or `SKIP`.                                    |
+| `.Duration`  | `time.Duration` | Duration of all test runs in this package.                                               |
+| `.Output`    | `string`        | Log output from the test.                                                                |
+| `.StartTime` | `*time.Time`    | A pointer to a time object when the test case was first seen in the output. May be nil.  |
+| `.EndTime`   | `*time.Time`    | A pointer to the time object when the test case was last seen in the output. May be nil. |
 
 #### Render settings
 
 Render settings are available in all templates. They have the following fields:
 
-| Variable | Type | Description |
-|----------|------|-------------|
-| `.HideSuccessfulDownloads` | `bool` | Hide successful package downloads from the output. |
-| `.HideSuccessfulPackages` | `bool` | Hide all packages that have only successful tests from the output. |
-| `.HideEmptyPackages` | `bool` | Hide the packages from the output that have no test cases. |
-| `.HideSuccessfulTests` | `bool` | Hide all tests from the output that are successful. |
-| `.ShowTestStatus` | `bool` | Show the test status next to the icons (PASS, FAIL, SKIP). |
+| Variable                   | Type   | Description                                                        |
+|----------------------------|--------|--------------------------------------------------------------------|
+| `.HideSuccessfulDownloads` | `bool` | Hide successful package downloads from the output.                 |
+| `.HideSuccessfulPackages`  | `bool` | Hide all packages that have only successful tests from the output. |
+| `.HideEmptyPackages`       | `bool` | Hide the packages from the output that have no test cases.         |
+| `.HideSuccessfulTests`     | `bool` | Hide all tests from the output that are successful.                |
+| `.ShowTestStatus`          | `bool` | Show the test status next to the icons (`PASS`, `FAIL`, `SKIP`).   |
 
 ## FAQ
 

--- a/parser/model.go
+++ b/parser/model.go
@@ -26,6 +26,8 @@ type TestCase struct {
 	Duration time.Duration
 	// Coverage is the percentage of code coverage in this test case, or a negative number if no coverage data is
 	// present.
+	//
+	// Deprecated: Coverage is not reported per testcase and should not be used.
 	Coverage *float64
 	// Output is the log output of this test case.
 	Output string


### PR DESCRIPTION
## Please describe the change you are making

This PR fixes #23, where the code coverage wasn't shown in the output with the default template.

Additionally, this PR removes the `.Coverage` field from test cases because Go doesn't report it.

## Your code will be released under [the Unlicense](LICENSE.md) into the public domain for everyone to use for any purpose. Are you in the position, and are you willing to release your code under this license?

Yes
