### PR TITLE
Fixes #33: Non-zero exit code if one or more tests failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Tadam, your tests will now show up in a beautifully formatted fashion. Plug it i
   - [Add your own CI](#add-your-own-ci)
 - [FAQ](#faq)
     - [How do I make the output less verbose?](#how-do-i-make-the-output-less-verbose)
-    - [How do I format the log lines within a test?](#how-do)
+    - [How do I format the log lines within a test?](#how-do-i-format-the-log-lines-within-a-test)
+    - [Why does gotestfmt exit with a non-zero status?](#why-does-gotestfmt-exit-with-a-non-zero-status)
     - [Can I use gotestfmt without `-json`?](#can-i-use-gotestfmt-without--json)
     - [Does gotestfmt work with Ginkgo?](#does-gotestfmt-work-with-ginkgo)
     - [I don't like `gotestfmt`. What else can I use?](#i-dont-like-gotestfmt-what-else-can-i-use)
@@ -298,6 +299,10 @@ go test -json -v ./... 2>&1 | gotestfmt -formatter "/path/to/your/formatter"
 The formatter will be called for each individual test case separately and the entire output of the test case will be passed to the formatter on the standard input. The formatter can then write the modified test output to the standard output. The formatter has 10 seconds to finish the test case, otherwise it will be terminated.
 
 You can find a sample formatter written in Go in [cmd/gotestfmt-formatter/main.go](cmd/gotestfmt-formatter/main.go).
+
+### Why does gotestfmt exit with a non-zero status?
+
+As of version 2.3.0 gotestfmt returns with a non-zero exit status when one or more tests fail. We added this behavior to make sure your CI doesn't pass on failing tests if you forget the `set -euo pipefail` option. You can disable this behavior by passing the `-nofail` parameter in the command line.
 
 ### How do I know what the icons mean in the output?
 

--- a/cmd/gotestfmt/main.go
+++ b/cmd/gotestfmt/main.go
@@ -97,6 +97,7 @@ func main() {
 	inputFile := "-"
 	formatter := ""
 	hide := ""
+	var nofail bool
 	var showTestStatus bool
 
 	flag.StringVar(
@@ -128,6 +129,12 @@ func main() {
 		"formatter",
 		formatter,
 		"Absolute path to an external program to format individual test output. This program will be called for each test case with a non-empty output and receive the test case output on stdin. It must produce the final output on stdout.",
+	)
+	flag.BoolVar(
+		&nofail,
+		"nofail",
+		nofail,
+		"Return an exit code of 0 even if one or more tests failed.",
 	)
 	flag.Parse()
 
@@ -172,5 +179,7 @@ func main() {
 	}
 
 	exitCode := format.FormatWithConfigAndExitCode(input, os.Stdout, cfg)
-	os.Exit(exitCode)
+	if !nofail {
+		os.Exit(exitCode)
+	}
 }

--- a/cmd/gotestfmt/main.go
+++ b/cmd/gotestfmt/main.go
@@ -171,5 +171,6 @@ func main() {
 		input = fh
 	}
 
-	format.FormatWithConfig(input, os.Stdout, cfg)
+	exitCode := format.FormatWithConfigAndExitCode(input, os.Stdout, cfg)
+	os.Exit(exitCode)
 }


### PR DESCRIPTION
## Please describe the change you are making

This PR fixes #33 and adds a non-zero exit status when one or more tests fail. This makes sure that CI doesn't pass if people forget `set -euo pipefail`.

## Your code will be released under [the Unlicense](LICENSE.md) into the public domain for everyone to use for any purpose. Are you in the position, and are you willing to release your code under this license?

Yes
