### PR TITLE
Fixes #42: incorrect output processing of in-test ok message

### DIFF
--- a/tokenizer/tokenizer.go
+++ b/tokenizer/tokenizer.go
@@ -158,6 +158,12 @@ var stateMachine = []stateChange{
 	},
 	{
 		regexp.MustCompile(`^ok\s+(?P<Package>[^\s]+)\s+(\((?P<Cached>cached)\)|(?P<Elapsed>[^\s]*))(|([\s]+)coverage: ((?P<Coverage>.*)% of statements|\[no statements]))$`),
+		stateRun,
+		ActionPass,
+		stateRun,
+	},
+	{
+		regexp.MustCompile(`^ok\s+(?P<Package>[^\s]+)\s+(\((?P<Cached>cached)\)|(?P<Elapsed>[^\s]*))(|([\s]+)coverage: ((?P<Coverage>.*)% of statements|\[no statements]))$`),
 		stateInit,
 		ActionPass,
 		stateBetweenTests,


### PR DESCRIPTION
## Please describe the change you are making

This change fixes #42 by accepting `ok ... ` lines within the test body.

## Your code will be released under [the Unlicense](LICENSE.md) into the public domain for everyone to use for any purpose. Are you in the position, and are you willing to release your code under this license?

Yes
